### PR TITLE
Hide the Cython import in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,41 @@
-from distutils.core import setup, Extension
-from Cython.Build import cythonize
+from setuptools import setup, Extension
 
-ext_modules = [
-    Extension("pyrevolve.crevolve",
-              sources=["pyrevolve/crevolve.pyx",
-                       "src/revolve_c.cpp",
-                       "src/revolve.cpp"],
-              include_dirs=[".", "pyrevolve"],
-              language="c++",
-              )
-]
 
-setup(
-    name="pyrevolve",
-    packages=["pyrevolve", "pyrevolve.crevolve"],
-    ext_modules=cythonize(ext_modules),
-    setup_requires=["Cython >= 0.20"]
-)
+class lazy_cythonize(list):
+    def __init__(self, callback):
+        self._list, self.callback = None, callback
+
+    def c_list(self):
+        if self._list is None:
+            self._list = self.callback()
+        return self._list
+
+    def __iter__(self):
+        for e in self.c_list():
+            yield e
+
+    def __getitem__(self, ii):
+        return self.c_list()[ii]
+
+    def __len__(self):
+        return len(self.c_list())
+
+
+def extensions():
+    from Cython.Build import cythonize
+    ext = Extension("pyrevolve.crevolve", sources=["pyrevolve/crevolve.pyx",
+                                                   "src/revolve_c.cpp",
+                                                   "src/revolve.cpp"],
+                    include_dirs=[".", "pyrevolve"], language="c++")
+    return cythonize([ext])
+
+
+configuration = {
+    'name': 'pyrevolve',
+    'packages': ["pyrevolve", "pyrevolve.crevolve"],
+    'setup_requires': ['cython>=0.17'],
+    'ext_modules': lazy_cythonize(extensions)
+}
+
+
+setup(**configuration)


### PR DESCRIPTION
 to give setuptools a chance to install Cython if not present

Use python, they said. It makes everything simple, they said. 