### PR TITLE
Setup: `pyrevolve.crevolve` is not a package

### DIFF
--- a/pyrevolve/__init__.py
+++ b/pyrevolve/__init__.py
@@ -1,3 +1,4 @@
 from __future__ import absolute_import
 
 from pyrevolve.pyrevolve import * # noqa
+from pyrevolve.crevolve import * # noqa

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def extensions():
 
 configuration = {
     'name': 'pyrevolve',
-    'packages': ["pyrevolve", "pyrevolve.crevolve"],
+    'packages': ["pyrevolve"],
     'setup_requires': ['cython>=0.17'],
     'ext_modules': lazy_cythonize(extensions)
 }


### PR DESCRIPTION
This should fix external pip installs. Please confirm before merging.